### PR TITLE
Updating http match condition according to PR 14386

### DIFF
--- a/content/en/docs/ops/common-problems/network-issues/index.md
+++ b/content/en/docs/ops/common-problems/network-issues/index.md
@@ -432,7 +432,10 @@ To fix this problem, you should switch the virtual service to specify `http` rou
 spec:
   ...
   http:
-  - match: ...
+  - match:
+    - headers:
+        ":authority":
+          regex: "*.example.com"
 {{< /text >}}
 
 #### Gateway with TLS passthrough


### PR DESCRIPTION
Updating the example given for working with Gateway TLS Termination and HTTP with a "header" match condition instead of using TLS with "sniHosts" match condition.

## Description

<!-- Please replace this line with a description of the PR. -->

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [x] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
